### PR TITLE
Get rid of global variables

### DIFF
--- a/lib/ace/mode/papeeria_latex.js
+++ b/lib/ace/mode/papeeria_latex.js
@@ -59,7 +59,7 @@ EditSession.prototype.removeAllMarkersByType = function(type) {
 
         // turn off spell checker only if "enabled" parameter is false
         session.on("changeSpellingCheckSettings", function(data) {
-            if (data.enabled == false) {
+            if (!data.enabled) {
                 session.removeAllMarkersByType("typo");
             }
             mySettingsUpdateCallbacks = {
@@ -71,7 +71,7 @@ EditSession.prototype.removeAllMarkersByType = function(type) {
                 language: data.language,
                 dicPath: data.dicPath,
                 affPath: data.affPath,
-                enabled: data.enabled != false
+                enabled: data.enabled
             }]);
         });
 


### PR DESCRIPTION
Can’t init callbacks because of strict mode
