### PR TITLE
Custom tokenizers in findOpening/ClosingBracket methods

### DIFF
--- a/lib/ace/edit_session/bracket_match.js
+++ b/lib/ace/edit_session/bracket_match.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2010, Ajax.org B.V.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -14,7 +14,7 @@
  *     * Neither the name of Ajax.org B.V. nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,7 +40,7 @@ function BracketMatch() {
     this.findMatchingBracket = function(position, chr) {
         if (position.column == 0) return null;
 
-        var charBeforeCursor = chr || this.getLine(position.row).charAt(position.column-1);
+        var charBeforeCursor = chr || this.getLine(position.row).charAt(position.column - 1);
         if (charBeforeCursor == "") return null;
 
         var match = charBeforeCursor.match(/([\(\[\{])|([\)\]\}])/);
@@ -48,11 +48,11 @@ function BracketMatch() {
             return null;
 
         if (match[1])
-            return this.$findClosingBracket(match[1], position);
+            return this.$findClosingBracket(match[1], position, this.$newDefaultForwardIterator(position));
         else
-            return this.$findOpeningBracket(match[2], position);
+            return this.$findOpeningBracket(match[2], position, this.$newDefaultBackwardIterator(position));
     };
-    
+
     this.getBracketRange = function(pos) {
         var line = this.getLine(pos.row);
         var before = true, range;
@@ -69,7 +69,7 @@ function BracketMatch() {
             return null;
 
         if (match[1]) {
-            var bracketPos = this.$findClosingBracket(match[1], pos);
+            var bracketPos = this.$findClosingBracket(match[1], pos, this.$newDefaultForwardIterator(pos));
             if (!bracketPos)
                 return null;
             range = Range.fromPoints(pos, bracketPos);
@@ -79,7 +79,7 @@ function BracketMatch() {
             }
             range.cursor = range.end;
         } else {
-            var bracketPos = this.$findOpeningBracket(match[2], pos);
+            var bracketPos = this.$findOpeningBracket(match[2], pos, this.$newDefaultBackwardIterator(pos));
             if (!bracketPos)
                 return null;
             range = Range.fromPoints(bracketPos, pos);
@@ -89,7 +89,7 @@ function BracketMatch() {
             }
             range.cursor = range.start;
         }
-        
+
         return range;
     };
 
@@ -102,39 +102,91 @@ function BracketMatch() {
         "}": "{"
     };
 
-    this.$findOpeningBracket = function(bracket, position, typeRe) {
+    this.$newFilteringIterator = function(tokenIterator, getNext) {
+        var result = {
+            $currentToken: function() {
+                return tokenIterator.getCurrentToken();
+            },
+            $currentRow: function() {
+                return tokenIterator.getCurrentTokenRow();
+            },
+            $currentColumn: function() {
+                return tokenIterator.getCurrentTokenColumn();
+            },
+            $current: null,
+            $updateCurrent: function() {
+                this.$current = {
+                    token: this.$currentToken(),
+                    row: this.$currentRow(),
+                    column: this.$currentColumn(),
+                    contains: function(pos) {
+                        return this.row == pos.row && this.column + this.token.value.length >= pos.column;
+                    }
+                };
+            },
+            current: function() {
+                return this.$current;
+            },
+            next: function() {
+                return getNext(this);
+            }
+        }
+        return result;
+    }
+
+    this.$newDefaultBackwardIterator = function(position, typeRe) {
+        var tokenIterator = new TokenIterator(this, position.row, position.column);
+        var token = tokenIterator.getCurrentToken();
+        if (!token)
+            token = tokenIterator.stepForward();
+        if (!token)
+            return null;
+        if (!typeRe) {
+           typeRe = new RegExp(
+               "(\\.?" +
+               token.type.replace(".", "\\.").replace("rparen", ".paren")
+                   .replace(/\b(?:end)\b/, "(?:start|begin|end)")
+               + ")+"
+           );
+        }
+        var result = this.$newFilteringIterator(tokenIterator, function(filteringIterator) {
+            // Scan backward through the document, looking for the next token
+            // whose type matches typeRe
+            do {
+                token = tokenIterator.stepBackward();
+            } while (token && !typeRe.test(token.type));
+
+            if (token == null)
+                return false;
+            filteringIterator.$updateCurrent();
+            return true;
+        });
+        result.$updateCurrent();
+        return result;
+    }
+
+    this.$findOpeningBracket = function(bracket, position, filteringIterator) {
+        if (!filteringIterator) {
+            return null;
+        }
         var openBracket = this.$brackets[bracket];
         var depth = 1;
 
-        var iterator = new TokenIterator(this, position.row, position.column);
-        var token = iterator.getCurrentToken();
-        if (!token)
-            token = iterator.stepForward();
-        if (!token)
-            return;
-        
-         if (!typeRe){
-            typeRe = new RegExp(
-                "(\\.?" +
-                token.type.replace(".", "\\.").replace("rparen", ".paren")
-                    .replace(/\b(?:end)\b/, "(?:start|begin|end)")
-                + ")+"
-            );
-        }
-        
         // Start searching in token, just before the character at position.column
-        var valueIndex = position.column - iterator.getCurrentTokenColumn() - 2;
-        var value = token.value;
-        
+        // If filtering iterator starts with the current token then we start searching from the cursor position
+        var valueIndex = filteringIterator.current().contains(position)
+            ? position.column - filteringIterator.current().column - 2
+            : filteringIterator.current().token.value.length - 1;
+
         while (true) {
-        
+            var value = filteringIterator.current().token.value;
             while (valueIndex >= 0) {
                 var chr = value.charAt(valueIndex);
                 if (chr == openBracket) {
                     depth -= 1;
                     if (depth == 0) {
-                        return {row: iterator.getCurrentTokenRow(),
-                            column: valueIndex + iterator.getCurrentTokenColumn()};
+                        return {row: filteringIterator.current().row,
+                            column: valueIndex + filteringIterator.current().column};
                     }
                 }
                 else if (chr == bracket) {
@@ -142,35 +194,23 @@ function BracketMatch() {
                 }
                 valueIndex -= 1;
             }
-
-            // Scan backward through the document, looking for the next token
-            // whose type matches typeRe
-            do {
-                token = iterator.stepBackward();
-            } while (token && !typeRe.test(token.type));
-
-            if (token == null)
+            if (!filteringIterator.next()) {
                 break;
-                
-            value = token.value;
-            valueIndex = value.length - 1;
+            }
+            valueIndex = filteringIterator.current().token.value.length - 1;
         }
-        
+
         return null;
     };
 
-    this.$findClosingBracket = function(bracket, position, typeRe) {
-        var closingBracket = this.$brackets[bracket];
-        var depth = 1;
-
-        var iterator = new TokenIterator(this, position.row, position.column);
-        var token = iterator.getCurrentToken();
+    this.$newDefaultForwardIterator = function(position, typeRe) {
+        var tokenIterator = new TokenIterator(this, position.row, position.column);
+        var token = tokenIterator.getCurrentToken();
         if (!token)
-            token = iterator.stepForward();
+            token = tokenIterator.stepForward();
         if (!token)
-            return;
-
-        if (!typeRe){
+            return null;
+        if (!typeRe) {
             typeRe = new RegExp(
                 "(\\.?" +
                 token.type.replace(".", "\\.").replace("lparen", ".paren")
@@ -178,21 +218,42 @@ function BracketMatch() {
                 + ")+"
             );
         }
+        var result = this.$newFilteringIterator(tokenIterator, function(filteringIterator) {
+            // Scan forward through the document, looking for the next token
+            // whose type matches typeRe
+            do {
+                token = tokenIterator.stepForward();
+            } while (token && !typeRe.test(token.type));
+            if (token) {
+                filteringIterator.$updateCurrent();
+                return true;
+            } else {
+                filteringIterator.$current = null;
+                return false;
+            }
+        });
+        result.$updateCurrent();
+        return result;
+    }
+    this.$findClosingBracket = function(bracket, position, filteringIterator) {
+        if (!filteringIterator) {
+            return null;
+        }
+        var closingBracket = this.$brackets[bracket];
+        var depth = 1;
 
-        // Start searching in token, after the character at position.column
-        var valueIndex = position.column - iterator.getCurrentTokenColumn();
-
+        // If filtering iterator starts with the current token then we start searching from the cursor position
+        var valueIndex = filteringIterator.current().contains(position) ? position.column - filteringIterator.current().column : 0;
         while (true) {
-
-            var value = token.value;
+            var value = filteringIterator.current().token.value;
             var valueLength = value.length;
             while (valueIndex < valueLength) {
                 var chr = value.charAt(valueIndex);
                 if (chr == closingBracket) {
                     depth -= 1;
                     if (depth == 0) {
-                        return {row: iterator.getCurrentTokenRow(),
-                            column: valueIndex + iterator.getCurrentTokenColumn()};
+                        return {row: filteringIterator.current().row,
+                            column: valueIndex + filteringIterator.current().column};
                     }
                 }
                 else if (chr == bracket) {
@@ -200,19 +261,12 @@ function BracketMatch() {
                 }
                 valueIndex += 1;
             }
-
-            // Scan forward through the document, looking for the next token
-            // whose type matches typeRe
-            do {
-                token = iterator.stepForward();
-            } while (token && !typeRe.test(token.type));
-
-            if (token == null)
+            if (!filteringIterator.next()) {
                 break;
-
+            }
             valueIndex = 0;
         }
-        
+
         return null;
     };
 }


### PR DESCRIPTION
These changes basically replace some code in `findOpeningBracket` and `findClosingBracket` with _filtering iterator_ abstraction. Default filtering iterators implementation keeps the same behavior as used to be in `find...` methods.