### PR TITLE
Changed labels json

### DIFF
--- a/lib/ace/ext/papeeria/tex_completer.coffee
+++ b/lib/ace/ext/papeeria/tex_completer.coffee
@@ -182,9 +182,11 @@ define((require, exports, module) ->
   )
 
 
+  getJsonFromUrl = (url, onSuccess) =>
+    $.getJSON(url).done((data) => onSuccess(data))
 
   processReferenceJson = (json) =>
-    return json.Labels?.map((elem) => {
+    return json?.map((elem) => {
       name: elem.caption
       value: elem.caption
       score: 1000
@@ -212,14 +214,15 @@ define((require, exports, module) ->
     * processJson -- function -- handler for defined type of json(citeJson, refJson, etc)
     * return object with fields name, value and (optional) meta, meta_score, score
     ###
-    constructor: (processJson) ->
+    constructor: (getJson, processJson) ->
       @lastFetchedUrl =  ""
       @cache = []
+      @getJson = getJson
       @processJson = processJson
 
     getReferences: (url, callback) =>
       if url != @lastFetchedUrl
-        $.getJSON(url).done((data) =>
+        @getJson(url, (data) =>
           if data?
             @cache = @processJson(data)
             callback(null, @cache)
@@ -247,8 +250,8 @@ define((require, exports, module) ->
 
   class TexCompleter
       constructor: ->
-        @refCache = new CompletionsCache(processReferenceJson)
-        @citeCache = new CompletionsCache(processCitationJson)
+        @refCache = new CompletionsCache(getJsonFromUrl, processReferenceJson)
+        @citeCache = new CompletionsCache(getJsonFromUrl, processCitationJson)
         @enabled = true
 
       init: (editor) =>

--- a/lib/ace/ext/papeeria/tex_completer.js
+++ b/lib/ace/ext/papeeria/tex_completer.js
@@ -7,7 +7,7 @@
   foo = null;
 
   define(function(require, exports, module) {
-    var BASIC_SNIPPETS, CITATION_SNIPPET, CompletionsCache, ENVIRONMENT_LABELS, ENVIRONMENT_STATE, EQUATION_ENVIRONMENTS, EQUATION_ENV_SNIPPETS, EQUATION_SNIPPETS, EQUATION_STATE, FIGURE_STATE, HashHandler, LIST_END_ENVIRONMENT, LIST_ENVIRONMENTS, LIST_KEYWORDS, LIST_SNIPPET, LIST_STATE, LatexParsingContext, OTHER_ENVIRONMENTS, PapeeriaLatexHighlightRules, REFERENCE_SNIPPET, TABLE_STATE, TexCompleter, compare, env, processCitationJson, processReferenceJson, showPopupIfTokenIsOneOfTypes;
+    var BASIC_SNIPPETS, CITATION_SNIPPET, CompletionsCache, ENVIRONMENT_LABELS, ENVIRONMENT_STATE, EQUATION_ENVIRONMENTS, EQUATION_ENV_SNIPPETS, EQUATION_SNIPPETS, EQUATION_STATE, FIGURE_STATE, HashHandler, LIST_END_ENVIRONMENT, LIST_ENVIRONMENTS, LIST_KEYWORDS, LIST_SNIPPET, LIST_STATE, LatexParsingContext, OTHER_ENVIRONMENTS, PapeeriaLatexHighlightRules, REFERENCE_SNIPPET, TABLE_STATE, TexCompleter, compare, env, getJsonFromUrl, processCitationJson, processReferenceJson, showPopupIfTokenIsOneOfTypes;
     HashHandler = require("ace/keyboard/hash_handler");
     PapeeriaLatexHighlightRules = require("ace/ext/papeeria/papeeria_latex_highlight_rules");
     LatexParsingContext = require("ace/ext/papeeria/latex_parsing_context");
@@ -156,10 +156,16 @@
         meta_score: 10
       };
     });
+    getJsonFromUrl = (function(_this) {
+      return function(url, onSuccess) {
+        return $.getJSON(url).done(function(data) {
+          return onSuccess(data);
+        });
+      };
+    })(this);
     processReferenceJson = (function(_this) {
       return function(json) {
-        var ref;
-        return (ref = json.Labels) != null ? ref.map(function(elem) {
+        return json != null ? json.map(function(elem) {
           return {
             name: elem.caption,
             value: elem.caption,
@@ -197,16 +203,17 @@
       * processJson -- function -- handler for defined type of json(citeJson, refJson, etc)
       * return object with fields name, value and (optional) meta, meta_score, score
        */
-      function CompletionsCache(processJson) {
+      function CompletionsCache(getJson, processJson) {
         this.getReferences = bind(this.getReferences, this);
         this.lastFetchedUrl = "";
         this.cache = [];
+        this.getJson = getJson;
         this.processJson = processJson;
       }
 
       CompletionsCache.prototype.getReferences = function(url, callback) {
         if (url !== this.lastFetchedUrl) {
-          return $.getJSON(url).done((function(_this) {
+          return this.getJson(url, (function(_this) {
             return function(data) {
               if (data != null) {
                 _this.cache = _this.processJson(data);
@@ -258,8 +265,8 @@
         this.setReferencesUrl = bind(this.setReferencesUrl, this);
         this.setEnabled = bind(this.setEnabled, this);
         this.init = bind(this.init, this);
-        this.refCache = new CompletionsCache(processReferenceJson);
-        this.citeCache = new CompletionsCache(processCitationJson);
+        this.refCache = new CompletionsCache(getJsonFromUrl, processReferenceJson);
+        this.citeCache = new CompletionsCache(getJsonFromUrl, processCitationJson);
         this.enabled = true;
       }
 

--- a/lib/ace/ext/papeeria/tex_completer_test.js
+++ b/lib/ace/ext/papeeria/tex_completer_test.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2017 BarD Software s.r.o
+// Author: Dmitry Barashev
+if (typeof process !== "undefined") {
+    require("amd-loader");
+}
+
+define(function(require, exports, module) {
+    var assert = require("ace/test/assertions");
+    var TexCompleter = require("ace/ext/papeeria/tex_completer");
+
+    module.exports = {
+        "test: references completer": function() {
+            texCompleter = new TexCompleter();
+            texCompleter.refCache.getJson = function(text, callback) {
+              callback(JSON.parse(text));
+            };
+            refJson = '[{"caption": "capt0", "type": "references"}, {"caption": "capt1", "type": "references"}]'
+            texCompleter.refCache.getReferences(refJson, function(wtf, labels) {
+              assert.ok(labels);
+              assert.equal(2, labels.length);
+              assert.equal("capt0", labels[0].name);
+              assert.equal("capt0", labels[0].value);
+              assert.equal("references", labels[0].meta);
+              assert.equal("capt1", labels[1].name);
+              assert.equal("capt1", labels[1].value);
+              assert.equal("references", labels[1].meta);
+            });
+        },
+    }
+});


### PR DESCRIPTION

In the latest version of the cross-reference parser all labels are packed into top-level array, without wrapping object with "Labels" field: https://github.com/bardsoftware/papeeria/commit/6344fe9c51c95752bfc40a5488805d2a38e04fc6